### PR TITLE
4 Switch to graphql-server-base

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sgohlke/graphql-prom-metrics",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "MetricsClient for @dreamit/graphql-server using prom-client library",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/sgohlke/graphql-prom-metrics#readme",
   "devDependencies": {
+    "@dreamit/graphql-server": "3.2.3",
     "@sgohlke/ts-base-dependencies": "1.0.5",
     "@types/express": "4.17.17",
     "cross-fetch": "3.1.5",
@@ -37,7 +38,7 @@
     "jest-html-reporters": "3.1.4"
   },
   "peerDependencies": {
-    "@dreamit/graphql-server": "^3.2.1",
+    "@sgohlke/graphql-server-base": "^1.0.0",
     "prom-client": "^14.0.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import {
     SCHEMA_VALIDATION_ERROR,
     SYNTAX_ERROR,
     VALIDATION_ERROR
-} from '@dreamit/graphql-server'
+} from '@sgohlke/graphql-server-base'
 
 /**
  * Metrics client using prom-client library, to collect metrics from application and GraphQL server.

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -3,6 +3,13 @@ import express, {Express} from 'express'
 import {Server} from 'node:http'
 import {
     GraphQLServer,
+    GraphQLServerOptions,
+    LogHelper,
+    JsonLogger,
+    LogLevel,
+    LogEntry,
+} from '@dreamit/graphql-server'
+import {
     FETCH_ERROR,
     GRAPHQL_ERROR,
     INVALID_SCHEMA_ERROR,
@@ -12,12 +19,7 @@ import {
     SYNTAX_ERROR,
     VALIDATION_ERROR,
     MetricsClient,
-    GraphQLServerOptions,
-    LogHelper,
-    JsonLogger,
-    LogLevel,
-    LogEntry,
-} from '@dreamit/graphql-server'
+} from '@sgohlke/graphql-server-base'
 import fetch from 'cross-fetch'
 import {Console} from 'node:console'
 


### PR DESCRIPTION
Switch to graphql-server-base to avoid circular dependencies.
Closes #4 